### PR TITLE
【質問詳細画面】投稿削除機能を作成

### DIFF
--- a/src/pages/PostDetails.vue
+++ b/src/pages/PostDetails.vue
@@ -126,8 +126,6 @@
           <!-- 内容 -->
           <textarea
             class="block-content__input-text"
-            cols="30"
-            rows="10"
             v-model="editPostData.text"
             placeholder="質問内容"
           ></textarea>
@@ -173,25 +171,43 @@
             <button
               class="form-answer__btn"
               @click="isEditingPost = true"
-              v-show="!isEditingPost"
+              v-if="!isEditingPost"
             >
               投稿を編集する
             </button>
             <!-- 編集モード -->
-            <div class="form-answer__edit-post" v-show="isEditingPost">
+            <template v-else>
+              <div class="form-answer__edit-post">
+                <button
+                  class="form-answer__btn form-answer__btn--half_cancel"
+                  @click="isEditingPost = false"
+                >
+                  キャンセル
+                </button>
+                <button
+                  class="form-answer__btn form-answer__btn--half_edit"
+                  @click="updatePost"
+                >
+                  編集
+                </button>
+              </div>
+              <h4 class="form-answer__title">質問を削除する</h4>
+              <p class="form-answer__text form-answer__text--delete">
+                「削除」と入力してください
+              </p>
+              <input
+                class="form-answer__input block-content__input-delete"
+                placeholder="削除"
+                v-model="deletePostText"
+              />
               <button
-                class="form-answer__btn form-answer__btn--half_cancel"
-                @click="isEditingPost = false"
+                class="form-answer__btn form-answer__btn--delete"
+                :disabled="deletePostText !== '削除'"
+                @click="deletePost"
               >
-                キャンセル
+                削除
               </button>
-              <button
-                class="form-answer__btn form-answer__btn--half_edit"
-                @click="updatePost"
-              >
-                編集
-              </button>
-            </div>
+            </template>
           </template>
 
           <!-- 未ログイン -->
@@ -559,6 +575,7 @@ export default {
       isEditingPost: false, // 質問を編集中かどうか
       editCategory: false, // カテゴリーを編集したかどうか
       isFullDisplay: false, // コメントを全表示するかどうか
+      deletePostText: "", // 投稿削除文
     };
   },
   created() {
@@ -812,6 +829,13 @@ export default {
 
       // フォームの文章を初期化
       this.newAnswer = "";
+    },
+    // 投稿を削除
+    deletePost() {
+      apiClient.delete("/posts/delete/" + this.post.id + "/")
+        .then(() => {
+          this.$router.replace("/");
+        });
     },
     // 回答にいいねする
     async like(answerId) {
@@ -1071,12 +1095,17 @@ ul {
   margin: 20px 0;
 }
 
+.block-content__input-delete {
+  height: 30px;
+}
+
 .form-answer__edit-post {
   display: flex;
+  justify-content: space-around;
 }
 
 [class*="form-answer__btn--half"] {
-  width: 50%;
+  width: 45%;
 }
 
 /* 物件情報 */
@@ -1209,6 +1238,16 @@ ul {
   padding: 10px 0;
 }
 
+.form-answer__text--delete {
+  display: flex;
+}
+
+.form-answer__title {
+  margin: 30px 0 20px;
+  padding-top: 10px;
+  border-top: 1px solid rgb(173, 172, 172);
+}
+
 .form-answer__btn {
   height: 40px;
   margin: 20px 0;
@@ -1232,6 +1271,10 @@ ul {
 
 .form-answer__btn--delete {
   background: rgb(231, 39, 39);
+}
+
+.form-answer__btn--delete:disabled {
+  opacity: 0.8;
 }
 
 .form-answer__btn:hover {


### PR DESCRIPTION
## Issue
#96 

## 概要
質問詳細画面に投稿を削除する機能を作成

## 動作確認内容
以下の処理を行い質問が正常に削除できることを確認

#### 削除前（質問編集下部）

![image](https://user-images.githubusercontent.com/83702606/139321315-54a0d687-9722-4b37-8054-1d23c46e0769.png)

#### 削除中
削除と入力するとボタンが押せるようになる

![image](https://user-images.githubusercontent.com/83702606/139321437-5cb76599-18e1-430b-915d-0e0f6da8e625.png)

#### 削除後（トップページへリダイレクト）

![image](https://user-images.githubusercontent.com/83702606/139321547-9f222932-4c24-4098-8150-ef2be3ed2798.png)

