### PR TITLE
【質問詳細画面】編集時のバグを修正

### DIFF
--- a/src/pages/PostDetails.vue
+++ b/src/pages/PostDetails.vue
@@ -994,6 +994,17 @@ export default {
         this.post = data; // 対象の投稿データをセット
         this.setEditCommentData(this.post.answers);
         this.setEditAnswerData(this.post.answers);
+
+        // 編集用データ
+        this.editPostData.title = data.title;
+        this.editPostData.text = data.text;
+        this.editPostData.property = data.property;
+        this.editAddressData = { ...data.address };
+        this.editCategoryData = [...data.categories];
+        this.editAddressData.postalCodeA = this.postalCodeA(this.post);
+        this.editAddressData.postalCodeB = this.postalCodeB(this.post);
+
+        this.isEditingPost = false;
       });
     },
   },


### PR DESCRIPTION
## 概要
質問詳細画面でサイドの質問リストから表示されている質問を切り替えたとき、編集用データが新しい質問の内容に切り替わらないバグが発生したので修正

## 動作確認内容
質問詳細画面のサイドメニューから別の質問を選択して編集画面を開いた際に、質問の内容が新しいものに変わっていることを確認