### PR TITLE
【ユーザー画面】メールアドレスとパスワード編集フォームのスタイルを修正

### DIFF
--- a/src/components/AuthInfo.vue
+++ b/src/components/AuthInfo.vue
@@ -84,22 +84,23 @@ export default {
 /* フォーム部分 */
 .block-email {
   display: flex;
+  flex-direction: column;
   align-items: center;
   width: 100%;
 }
 
 /* ラベル要素 */
 .block-email__label {
+  align-self: flex-start;
   font-weight: bold;
-  font-size: 1.2em;
   letter-spacing: 1px;
 }
 
 /* input要素 */
 .block-email__input {
   flex-grow: 3;
-  height: 30px;
-  margin-left: 20px;
+  width: 95%;
+  height: 20px;
   border: 1px solid silver;
   border-radius: 4px;
 }
@@ -121,24 +122,7 @@ export default {
   justify-content: flex-end;
   width: 100%;
   margin: 15px 10px 0;
-  letter-spacing: 1px;
   text-decoration: none;
-}
-
-@media screen and (max-width: 599px) {
-  .block-email {
-    flex-direction: column;
-  }
-
-  .block-email__label {
-    align-self: flex-start;
-    font-size: 1em;
-  }
-
-  .block-email__input {
-    width: 95%;
-    height: 20px;
-    margin-left: 0;
-  }
+  font-size: 0.8em;
 }
 </style>

--- a/src/components/ChangePassword.vue
+++ b/src/components/ChangePassword.vue
@@ -158,7 +158,7 @@ export default {
   flex-direction: column;
   width: 80%;
   margin: 0 auto;
-  padding: 20px;
+  padding: 10px 20px 20px;
   background: #fff;
 }
 
@@ -166,21 +166,22 @@ export default {
 .block-input__label {
   margin-right: 20px;
   font-weight: bold;
-  font-size: 1.2em;
   letter-spacing: 1px;
 }
 
 /* 各入力部分 */
 .block-input {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   width: 100%;
   margin-top: 10px;
 }
 
 .block-input__input {
   flex-grow: 3;
-  height: 25px;
+  width: 100%;
+  height: 20px;
   border: 1px solid gray;
   border-radius: 4px;
 }
@@ -194,17 +195,5 @@ export default {
   background: green;
   color: white;
   cursor: pointer;
-}
-
-@media screen and (max-width: 599px) {
-  .block-input {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .block-input__input {
-    width: 100%;
-    height: 20px;
-  }
 }
 </style>


### PR DESCRIPTION
## Issue
#111 

## 概要
ユーザー画面のメールアドレス・パスワード編集フォームのスタイルを修正

## 動作確認内容
ユーザー画面を開いてスタイルに崩れがないことを確認

#### メールアドレス編集フォーム
![image](https://user-images.githubusercontent.com/83702606/140468074-2af7cbc8-3ffc-4c68-97ca-d1e5c1724ba8.png)


#### パスワード編集フォーム
![image](https://user-images.githubusercontent.com/83702606/140468010-0b73d6b8-9de5-4dae-9173-f50eaa7e4e7f.png)
