### PR TITLE
【ユーザー画面】コンポーネントを用いてコンテンツ表示部分のコードを簡略化

### DIFF
--- a/src/components/AnswerListContent.vue
+++ b/src/components/AnswerListContent.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="block-answer-list-content">
+    <ContentTitle :title="title" :showMenuFunc="showMenuFunc" />
+    <Content :isScroll="true">
+      <AnswerList :answerType="answerType" :userIdProps="userIdProps" />
+    </Content>
+  </div>
+</template>
+
+<script>
+import ContentTitle from "@/components/ContentTitle";
+import Content from "@/components/Content";
+import AnswerList from "@/components/AnswerList";
+
+export default {
+  components: {
+    ContentTitle,
+    Content,
+    AnswerList,
+  },
+  props: {
+    answerType: String,
+    userIdProps: String,
+    showMenuFunc: {
+      type: Function,
+      default: () => {},
+    },
+  },
+  computed: {
+    title() {
+      return this.answerType === "answer" ? "ユーザーの回答" : "いいねした回答";
+    },
+  },
+};
+</script>

--- a/src/components/AuthInfo.vue
+++ b/src/components/AuthInfo.vue
@@ -1,33 +1,50 @@
 <template>
-  <div class="container-auth-info">
-    <!-- メールアドレス -->
-    <div class="block-email">
-      <label for="email" class="block-email__label">メールアドレス</label>
-      <input
-        class="block-email__input"
-        type="text"
-        name="email"
-        v-model="userEmail"
-      />
-    </div>
-    <ValidationMessage
-      :messages="emailMessages"
-      v-show="emailMessages.length"
-    />
-    <button class="container-auth-info__btn" @click="changeEmail">保存</button>
-    <router-link
-      :to="{ name: 'changePassword' }"
-      class="container-auth-info__link"
-      >パスワードの変更</router-link
-    >
+  <div class="block-auth-info">
+    <ContentTitle title="認証情報" :showMenuFunc="showMenuFunc" />
+    <Content>
+      <div class="container-auth-info">
+        <!-- メールアドレス -->
+        <div class="block-email">
+          <label for="email" class="block-email__label">メールアドレス</label>
+          <input
+            class="block-email__input"
+            type="text"
+            name="email"
+            v-model="userEmail"
+          />
+        </div>
+        <ValidationMessage
+          :messages="emailMessages"
+          v-show="emailMessages.length"
+        />
+        <button class="container-auth-info__btn" @click="changeEmail">
+          保存
+        </button>
+        <router-link
+          :to="{ name: 'changePassword' }"
+          class="container-auth-info__link"
+          >パスワードの変更</router-link
+        >
+      </div>
+    </Content>
   </div>
 </template>
 
 <script>
+import ContentTitle from "@/components/ContentTitle";
+import Content from "@/components/Content";
 import ValidationMessage from "@/components/ValidationMessage";
 
 export default {
+  props: {
+    showMenuFunc: {
+      type: Function,
+      default: () => {},
+    },
+  },
   components: {
+    ContentTitle,
+    Content,
     ValidationMessage,
   },
   data() {
@@ -78,7 +95,6 @@ export default {
   width: 80%;
   margin: 0 auto;
   padding: 20px;
-  background: #fff;
 }
 
 /* フォーム部分 */

--- a/src/components/ChangePassword.vue
+++ b/src/components/ChangePassword.vue
@@ -1,69 +1,84 @@
 <template>
-  <div class="container-change-password">
-    <!-- パスワード変更フォーム -->
-    <div class="block-input">
-      <label class="block-input__label" for="current_password"
-        >現在のパスワード</label
-      >
-      <input
-        class="block-input__input"
-        type="password"
-        name="current_password"
-        v-model="currentPassword"
-      />
-    </div>
-    <ValidationMessage
-      class="container-change-password__validation"
-      :messages="currentPasswdMessage"
-      v-show="currentPasswdMessage.length"
-    />
-    <div class="block-input">
-      <label class="block-input__label" for="new_password"
-        >新しいパスワード</label
-      >
-      <input
-        class="block-input__input"
-        type="password"
-        name="new_password"
-        v-model="newPassword"
-      />
-    </div>
-    <ValidationMessage
-      class="container-change-password__validation"
-      :messages="newPasswdMessage"
-      v-show="newPasswdMessage.length"
-    />
-    <div class="block-input">
-      <label class="block-input__label" for="current_password"
-        >確認用パスワード</label
-      >
-      <input
-        class="block-input__input"
-        type="password"
-        name="current_password"
-        v-model="cfmPassword"
-      />
-    </div>
-    <ValidationMessage
-      class="container-change-password__validation"
-      :messages="cfmPasswdMessage"
-      v-show="cfmPasswdMessage.length"
-    />
+  <div class="block-change-password">
+    <ContentTitle title="パスワードの変更" :showMenuFunc="showMenuFunc" />
+    <Content>
+      <div class="container-change-password">
+        <!-- パスワード変更フォーム -->
+        <div class="block-input">
+          <label class="block-input__label" for="current_password"
+            >現在のパスワード</label
+          >
+          <input
+            class="block-input__input"
+            type="password"
+            name="current_password"
+            v-model="currentPassword"
+          />
+        </div>
+        <ValidationMessage
+          class="container-change-password__validation"
+          :messages="currentPasswdMessage"
+          v-show="currentPasswdMessage.length"
+        />
+        <div class="block-input">
+          <label class="block-input__label" for="new_password"
+            >新しいパスワード</label
+          >
+          <input
+            class="block-input__input"
+            type="password"
+            name="new_password"
+            v-model="newPassword"
+          />
+        </div>
+        <ValidationMessage
+          class="container-change-password__validation"
+          :messages="newPasswdMessage"
+          v-show="newPasswdMessage.length"
+        />
+        <div class="block-input">
+          <label class="block-input__label" for="current_password"
+            >確認用パスワード</label
+          >
+          <input
+            class="block-input__input"
+            type="password"
+            name="current_password"
+            v-model="cfmPassword"
+          />
+        </div>
+        <ValidationMessage
+          class="container-change-password__validation"
+          :messages="cfmPasswdMessage"
+          v-show="cfmPasswdMessage.length"
+        />
 
-    <!-- ボタン -->
-    <button class="container-change-password__btn" @click="changePassword">
-      保存
-    </button>
+        <!-- ボタン -->
+        <button class="container-change-password__btn" @click="changePassword">
+          保存
+        </button>
+      </div>
+    </Content>
   </div>
 </template>
 
 
 <script>
+import ContentTitle from "@/components/ContentTitle";
+import Content from "@/components/Content";
 import ValidationMessage from "@/components/ValidationMessage";
 
 export default {
+  props: {
+    showMenuFunc: {
+      type: Function,
+      default: () => {},
+    },
+  },
   components: {
     ValidationMessage,
+    ContentTitle,
+    Content,
   },
   data() {
     return {
@@ -159,7 +174,6 @@ export default {
   width: 80%;
   margin: 0 auto;
   padding: 10px 20px 20px;
-  background: #fff;
 }
 
 /* ラベル要素 */
@@ -182,6 +196,7 @@ export default {
   flex-grow: 3;
   width: 100%;
   height: 20px;
+  box-sizing: border-box;
   border: 1px solid gray;
   border-radius: 4px;
 }

--- a/src/components/Content.vue
+++ b/src/components/Content.vue
@@ -1,0 +1,37 @@
+<template>
+  <div :class="{ 'block-content': true, 'block-content--scroll': isScroll }">
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    isScroll: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style scoped>
+.block-content {
+  max-height: 280px;
+  overflow-wrap: break-word;
+}
+
+.block-content--scroll {
+  overflow-y: scroll;
+}
+
+::-webkit-scrollbar {
+  width: 5px;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 5px;
+  background: rgba(158, 154, 154, 0.781);
+}
+</style>
+

--- a/src/components/ContentTitle.vue
+++ b/src/components/ContentTitle.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="block-title">
+    <a
+      href=""
+      class="block-title__btn"
+      v-if="width < 600"
+      @click.prevent="showMenuFunc"
+    >
+      <fa-icon class="block-title__icon" icon="bars" />
+    </a>
+    <span class="block-title__text">{{ title }}</span>
+  </div>
+</template>
+
+<script>
+import widthMixin from "@/mixins/widthMixin";
+
+export default {
+  props: {
+    title: {
+      type: String,
+      default: "",
+    },
+    showMenuFunc: {
+      type: Function,
+      default: () => {},
+    },
+  },
+  mixins: [widthMixin], 
+};
+</script>
+
+<style scoped>
+.block-title {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 50px;
+  background: silver;
+  font-size: 1em;
+  text-align: center;
+}
+
+.block-title__icon {
+  margin-right: 10px;
+  color: gray;
+}
+
+.block-title__text {
+  font-weight: bold;
+}
+</style>

--- a/src/components/Follow.vue
+++ b/src/components/Follow.vue
@@ -1,28 +1,41 @@
 <template>
   <div class="block-follow">
-    <FollowsList :followsList="followees" />
-    <Pagination
-      class="block-follow__pagination"
-      :total="followTotal.followee"
-      :pageNumber="followPage.followee"
-      :paginationFunc="pagination"
-    />
+    <ContentTitle title="フォロー" :showMenuFunc="showMenuFunc" />
+    <Content :isScroll="true">
+      <div class="container-follow">
+        <FollowsList :followsList="followees" />
+        <Pagination
+          class="container-follow__pagination"
+          :total="followTotal.followee"
+          :pageNumber="followPage.followee"
+          :paginationFunc="pagination"
+        />
+      </div>
+    </Content>
   </div>
 </template>
 
 <script>
 import FollowsList from "@/components/FollowsList";
 import Pagination from "@/components/Pagination";
+import ContentTitle from "@/components/ContentTitle";
+import Content from "@/components/Content";
 import followData from "@/mixins/followData";
 
 export default {
   components: {
     FollowsList,
     Pagination,
+    ContentTitle,
+    Content,
   },
   mixins: [followData],
   props: {
     userIdProps: String,
+    showMenuFunc: {
+      type: Function,
+      default: () => {},
+    },
   },
   created() {
     this.getFollowees(1, this.userIdProps);
@@ -36,7 +49,7 @@ export default {
 </script>
 
 <style scoped>
-.block-follow__pagination {
+.container-follow__pagination {
   padding: 5px 0;
 }
 </style>

--- a/src/components/Follower.vue
+++ b/src/components/Follower.vue
@@ -1,28 +1,41 @@
 <template>
   <div class="block-follower">
-    <FollowsList :followsList="followers" />
-    <Pagination
-      class="block-follower__pagination"
-      :total="followTotal.follower"
-      :pageNumber="followPage.follower"
-      :paginationFunc="pagination"
-    />
+    <ContentTitle title="フォロワー" :showMenuFunc="showMenuFunc" />
+    <Content :isScroll="true">
+      <div class="container-follower">
+        <FollowsList :followsList="followers" />
+        <Pagination
+          class="container-follower__pagination"
+          :total="followTotal.follower"
+          :pageNumber="followPage.follower"
+          :paginationFunc="pagination"
+        />
+      </div>
+    </Content>
   </div>
 </template>
 
 <script>
 import FollowsList from "@/components/FollowsList";
 import Pagination from "@/components/Pagination";
+import ContentTitle from "@/components/ContentTitle";
+import Content from "@/components/Content";
 import followData from "@/mixins/followData";
 
 export default {
   components: {
     FollowsList,
     Pagination,
+    ContentTitle,
+    Content,
   },
   mixins: [followData],
   props: {
     userIdProps: String,
+    showMenuFunc: {
+      type: Function,
+      default: () => {},
+    },
   },
   created() {
     this.getFollowers(1, this.userIdProps);
@@ -36,7 +49,7 @@ export default {
 </script>
 
 <style scoped>
-.block-follower__pagination {
+.container-follower__pagination {
   padding: 5px 0;
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -106,6 +106,7 @@
 <script>
 import SubMenu from "@/components/SubMenu";
 import authInfoMixin from "@/mixins/authInfoMixin";
+import widthMixin from "@/mixins/widthMixin";
 import { mapGetters, mapMutations } from "vuex";
 
 export default {
@@ -116,19 +117,12 @@ export default {
     return {
       logo: require("@/assets/BUKKEN_logo.png"),
       noSubMenuRoute: ["home"],
-      width: window.innerWidth,
     };
   },
   computed: {
     ...mapGetters("home", ["showSideMenu"]),
   },
-  mounted() {
-    // 画面幅の変更を感知
-    window.addEventListener("resize", () => {
-      this.width = window.innerWidth;
-    });
-  },
-  mixins: [authInfoMixin],
+  mixins: [authInfoMixin, widthMixin],
   methods: {
     ...mapMutations("home", ["toggleSideMenu", "hideSideMenu"]),
     // プルダウンメニュー展開

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -98,6 +98,8 @@
 </template>
 
 <script>
+import widthMixin from "@/mixins/widthMixin";
+
 export default {
   props: {
     total: Number, // 総ページ数
@@ -110,17 +112,7 @@ export default {
       default: 0,
     },
   },
-  data() {
-    return {
-      width: window.innerWidth,
-    };
-  },
-  mounted() {
-    // 画面幅の変更を感知
-    window.addEventListener("resize", () => {
-      this.width = window.innerWidth;
-    });
-  },
+  mixins: [widthMixin],
   methods: {
     // ページボタンの表示・非表示
     displayPageButton(num) {

--- a/src/components/SelfIntroduction.vue
+++ b/src/components/SelfIntroduction.vue
@@ -1,43 +1,48 @@
 <template>
   <!-- 自己紹介 -->
   <div class="item-self-intro">
-    <p class="item-self-intro__text" v-if="selfIntroduction">{{ selfIntroduction }}</p>
-    <p class="item-self-intro__text item-self-intro__text--no_text" v-else>
-      自己紹介は<span>ありません</span>
-    </p>
+    <ContentTitle title="プロフィール" :showMenuFunc="showMenuFunc" />
+    <Content :isScroll="true">
+      <p class="item-self-intro__text" v-if="selfIntroduction">
+        {{ selfIntroduction }}
+      </p>
+      <p class="item-self-intro__text item-self-intro__text--no_text" v-else>
+        自己紹介は<span>ありません</span>
+      </p>
+    </Content>
   </div>
 </template>
 
 <script>
+import ContentTitle from "@/components/ContentTitle";
+import Content from "@/components/Content";
+
 export default {
+  components: {
+    ContentTitle,
+    Content,
+  },
   props: {
     selfIntroduction: String,
+    showMenuFunc: {
+      type: Function,
+      default: () => {},
+    },
   },
 };
 </script>
 
 <style scoped>
-/* 自己紹介 */
-.item-self-intro {
-  padding: 10px 50px;
-  overflow-wrap: break-word;
-  background: #fff;
-}
-
 .item-self-intro__text {
-  white-space: pre-wrap;
+  margin: 10px 0;
+  padding: 10px 5px;
 }
 
 .item-self-intro__text--no_text {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  align-items: center;
   color: gray;
-}
-
-@media screen and (max-width: 1024px) {
-  .item-self-intro {
-    padding: 10px;
-  }
 }
 </style>

--- a/src/mixins/widthMixin.js
+++ b/src/mixins/widthMixin.js
@@ -1,0 +1,12 @@
+export default {
+  data() {
+    return {
+      width: window.innerWidth,
+    };
+  },
+  mounted() {
+    window.addEventListener("resize", () => {
+      this.width = window.innerWidth;
+    });
+  },
+};

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -212,6 +212,7 @@ import Pagination from "@/components/Pagination";
 import apiClient from "@/axios";
 import { mapGetters, mapMutations } from "vuex";
 import followData from "@/mixins/followData";
+import widthMixin from "@/mixins/widthMixin";
 
 export default {
   components: {
@@ -222,7 +223,7 @@ export default {
     PostFilter,
     Pagination,
   },
-  mixins: [followData],
+  mixins: [followData, widthMixin],
   data() {
     return {
       total: 0,
@@ -252,7 +253,6 @@ export default {
         followee: { name: "フォロー", type: "followee" },
         follower: { name: "フォロワー", type: "follower" },
       },
-      width: window.innerWidth,
       showFolloweeList: false,
       showFollowerList: false,
       showAppOverview: false, // 概要の表示・非表示
@@ -273,12 +273,6 @@ export default {
       this.getFollowers(1),
     ]);
     this.setIsLoading(false);
-  },
-  mounted() {
-    // 画面幅の変更を感知
-    window.addEventListener("resize", () => {
-      this.width = window.innerWidth;
-    });
   },
   computed: {
     ...mapGetters("auth", ["userId", "isLoggedIn"]),

--- a/src/pages/UserAnswerView.vue
+++ b/src/pages/UserAnswerView.vue
@@ -46,6 +46,7 @@
 import AnswerList from "@/components/AnswerList";
 import apiClient from "@/axios";
 import { mapGetters } from "vuex";
+import widthMixin from "@/mixins/widthMixin";
 
 export default {
   props: {
@@ -53,6 +54,7 @@ export default {
     userId: String,
   },
   components: { AnswerList },
+  mixins: [widthMixin],
   data() {
     return {
       sideMenu: [
@@ -61,19 +63,12 @@ export default {
       ],
       type: this.answerType,
       userData: {},
-      width: window.innerWidth,
     };
   },
   async created() {
     const { data } = await apiClient.get("/users/" + this.userId + "/");
     this.userData = data;
     this.$store.commit("home/setIsLoading", false);
-  },
-  mounted() {
-    // 画面幅の変更を感知
-    window.addEventListener("resize", () => {
-      this.width = window.innerWidth;
-    });
   },
   computed: {
     ...mapGetters("home", ["showSideMenu"]),

--- a/src/pages/UserView.vue
+++ b/src/pages/UserView.vue
@@ -55,30 +55,13 @@
           class="container__section"
           v-show="!showSideMenu || width >= 600"
         >
-          <h2 class="container__title">
-            <a
-              href=""
-              class="container__btn-menu"
-              v-if="width < 600"
-              @click.prevent="showSideMenu = !showSideMenu"
-            >
-              <fa-icon class="container__icon-menu" icon="bars" />
-            </a>
-            <span v-show="$route.name !== 'answerList'">
-              {{ contentListTitle[$route.name] }}
-            </span>
-            <span v-show="$route.name === 'answerList'">
-              {{ answerListTitle[$route.params.answerType] }}
-            </span>
-          </h2>
-          <div :class="{ 'item-content': true, container__scroll: isScroll }">
-            <transition name="fade" mode="out-in" appear>
-              <router-view
-                :userIdProps="id"
-                :selfIntroduction="displayedSelfIntroduction"
-              />
-            </transition>
-          </div>
+          <transition name="fade" mode="out-in" appear>
+            <router-view
+              :userIdProps="id"
+              :selfIntroduction="displayedSelfIntroduction"
+              :showMenuFunc="toggleShowSideMenu"
+            />
+          </transition>
         </section>
 
         <!-- メニュー -->
@@ -157,6 +140,7 @@
 import ModalWindow from "@/components/ModalWindow";
 import DeleteAccount from "@/components/DeleteAccount";
 import authInfoMixin from "@/mixins/authInfoMixin";
+import widthMixin from "@/mixins/widthMixin";
 import apiClient from "@/axios";
 import { mapGetters, mapActions } from "vuex";
 
@@ -179,18 +163,6 @@ export default {
       slotName: "", // 表示するモーダルウィンドウ
       modalTitle: "", // モーダルのタイトル
       showWindow: false, // モーダルウィンドウの表示・非表示
-      contentListTitle: {
-        userView: "プロフィール",
-        authInfo: "認証情報",
-        changePassword: "パスワードの変更",
-        followList: "フォロー",
-        followerList: "フォロワー",
-      },
-      answerListTitle: {
-        answer: "ユーザーの回答",
-        like: "いいねした回答",
-      },
-      width: window.innerWidth,
       showSideMenu: false,
       // サイドメニュー一覧
       sideMenuList: [
@@ -287,7 +259,7 @@ export default {
       ],
     };
   },
-  mixins: [authInfoMixin],
+  mixins: [authInfoMixin, widthMixin],
   computed: {
     ...mapGetters("followeeId", ["followeeId"]),
     // 自分のページかどうか判定
@@ -297,17 +269,6 @@ export default {
     // フォローしているユーザーか判定
     isYourFavoriteUser() {
       return this.followeeId.some((el) => el === this.id);
-    },
-    isScroll() {
-      // コンテンツリストにスクロールバーを表示しないルート
-      const notScrollRoutes = ["authInfo", "changePassword"];
-
-      // スクロールバーを表示しない場合
-      if (notScrollRoutes.includes(this.$route.name)) {
-        return false;
-      }
-      // スクロールバーを表示する場合
-      return true;
     },
     userInfo() {
       // マイページではないときにユーザーの情報のオブジェクトを返す
@@ -342,12 +303,6 @@ export default {
       this.displayedIconURL = this.iconURL;
     }
     this.$store.commit("home/setIsLoading", false);
-  },
-  mounted() {
-    // 画面幅の変更を感知
-    window.addEventListener("resize", () => {
-      this.width = window.innerWidth;
-    });
   },
   methods: {
     ...mapActions("followeeId", ["createFolloweeId", "deleteFolloweeId"]),
@@ -407,6 +362,10 @@ export default {
       } else {
         await this.deleteFolloweeId({ followId: this.id, userId: this.userId });
       }
+    },
+    // サイドメニュー表示切り替え
+    toggleShowSideMenu() {
+      this.showSideMenu = !this.showSideMenu;
     },
   },
   beforeRouteEnter(to, from, next) {
@@ -543,45 +502,11 @@ a {
 /* コンテンツのリスト */
 .container__section {
   width: 50%;
-  min-height: 90px;
   overflow: hidden;
-  border: 3px solid gray;
+  border: 2px solid gray;
   border-radius: 5px;
-  animation: slideUp 0.8s;
-}
-
-.container__title {
-  position: relative;
-  font-size: 1em;
-  text-align: center;
-}
-
-.container__btn-menu {
-  position: absolute;
-  left: 10px;
-}
-
-.container__icon-menu {
-  color: gray;
-}
-
-.item-content {
-  max-height: 300px;
   background: #fff;
-}
-
-/* スクロールバー */
-.container__scroll {
-  overflow-y: scroll;
-}
-
-::-webkit-scrollbar {
-  width: 10px;
-}
-
-::-webkit-scrollbar-thumb {
-  border-radius: 5px;
-  background: rgba(158, 154, 154, 0.781);
+  animation: slideUp 0.8s;
 }
 
 /* サイドメニュー */
@@ -631,7 +556,7 @@ a {
 
 .fade-enter-active,
 .fade-leave-acitve {
-  transition: opacity 0.3s;
+  transition: opacity 0.5s;
 }
 
 @keyframes open {

--- a/src/router.js
+++ b/src/router.js
@@ -35,8 +35,10 @@ const Follow = () =>
   import(/* webpackChankName: 'Follow' */ "./components/Follow");
 const Follower = () =>
   import(/* webpackChankName: 'Follower' */ "./components/Follower");
-const AnswerList = () =>
-  import(/* webpackChankName: 'AnswerList' */ "./components/AnswerList");
+const AnswerListContent = () =>
+  import(
+    /* webpackChankName: 'AnswerListContent' */ "./components/AnswerListContent"
+  );
 
 Vue.use(VueRouter);
 
@@ -80,7 +82,7 @@ const router = new VueRouter({
         { path: "follower/list", component: Follower, name: "followerList" },
         {
           path: "answers/:answerType",
-          component: AnswerList,
+          component: AnswerListContent,
           name: "answerList",
           props: true,
         },


### PR DESCRIPTION
## Issue
#116 

## 概要
ユーザー画面のコンテンツ表示部分のコードを簡略化

以下詳細
- コンテンツのタイトルと内容部分のコンポーネントを作成
- 回答、フォロー、プロフィール、認証情報、パスワード変更のコンポーネントを上記のコンポーネントを使って修正
- ページのwidth監視機能をmixinで共通化

## 動作確認内容
ユーザー画面を開いてサイドメニューを選択して各コンテンツが正常に表示されることを確認

#### プロフィール
![image](https://user-images.githubusercontent.com/83702606/141077295-a0686293-f5de-4b05-b3f1-4e77d49d67ff.png)

#### フォローしているユーザー
![image](https://user-images.githubusercontent.com/83702606/141077528-2aba0058-9239-4123-8634-8c14e931e3ef.png)

#### フォロワー
![image](https://user-images.githubusercontent.com/83702606/141077579-f4a48731-ed5d-41da-a56b-2f4461c450fd.png)

#### ユーザーの回答
![image](https://user-images.githubusercontent.com/83702606/141077648-d1fa50f7-05c8-4991-8e68-ee27a6e86546.png)

#### いいねした回答
![image](https://user-images.githubusercontent.com/83702606/141077710-cf4f865a-5996-4d13-b047-948d65455f5d.png)

#### 認証情報
![image](https://user-images.githubusercontent.com/83702606/141077814-d0d30fae-0415-47df-9c8d-6ab52c236368.png)

#### パスワードの変更
![image](https://user-images.githubusercontent.com/83702606/141077878-fa407959-3a03-4364-a361-7261f9eabfa2.png)

