### PR TITLE
【質問詳細画面】回答に物件の評価をつけられる機能を作成

### DIFF
--- a/src/components/AnswerForm.vue
+++ b/src/components/AnswerForm.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="block-answer-form">
+    <textarea
+      class="block-answer-form__textarea"
+      placeholder="回答を投稿する"
+      v-model="answerObj.content"
+    ></textarea>
+    <ValidationMessage
+      class="block-answer-form__validation"
+      :messages="validations"
+    />
+    <div class="block-radio">
+      <p class="block-radio__help">質問に対する物件の評価</p>
+      <input
+        class="block-radio__item"
+        type="radio"
+        value="1"
+        v-model="answerObj.evaluation"
+      />良い
+      <input
+        class="block-radio__item"
+        type="radio"
+        value="0"
+        v-model="answerObj.evaluation"
+      />普通
+      <input
+        class="block-radio__item"
+        type="radio"
+        value="2"
+        v-model="answerObj.evaluation"
+      />悪い
+    </div>
+    <button
+      class="block-answer-form__btn"
+      @click="buttonFunc(answerObj)"
+      :disabled="isDisabled"
+      v-if="!isTwoButton"
+    >
+      回答
+    </button>
+    <div class="block-answer-form__two-button" v-else>
+      <button
+        class="block-answer-form__btn block-answer-form__btn--cancel"
+        @click="cancelFunc(answerId, false, { cancel: true })"
+      >
+        キャンセル
+      </button>
+      <button
+        class="block-answer-form__btn"
+        @click="buttonFunc(answerObj, answerId)"
+        :disabled="isDisabled.editAnswer"
+      >
+        保存
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import ValidationMessage from "@/components/ValidationMessage";
+
+export default {
+  components: {
+    ValidationMessage,
+  },
+  props: {
+    buttonFunc: {
+      type: Function,
+      default: () => {},
+    },
+    isDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    validations: {
+      type: Array,
+      dafault: () => [],
+    },
+    isTwoButton: {
+      type: Boolean,
+      default: false,
+    },
+    cancelFunc: {
+      type: Function,
+      default: () => {},
+    },
+    answerId: {
+      type: String,
+      default: "",
+    },
+    defaultData: {
+      type: Object,
+      default: () => ({ content: "", evaluation: 0 }),
+    },
+  },
+  data() {
+    return {
+      answerObj: {
+        content: this.defaultData.content,
+        evaluation: this.defaultData.evaluation,
+      },
+    };
+  },
+};
+</script>
+
+<style scoped>
+.block-answer-form {
+  display: flex;
+  flex-direction: column;
+  padding-top: 10px;
+}
+
+.block-answer-form__textarea {
+  height: 130px;
+  padding: 10px;
+  border-color: silver;
+  border-radius: 3px;
+  font-size: 1.1em;
+  letter-spacing: 2px;
+}
+
+.block-answer-form__validation {
+  margin: 0;
+}
+
+.block-radio {
+  font-size: 0.8em;
+}
+
+.block-radio__help {
+  font-size: 1.1em;
+  margin: 10px 0 5px;
+}
+
+.block-radio__item + .block-radio__item {
+  margin-left: 10px;
+}
+
+.block-answer-form__btn {
+  height: 40px;
+  margin: 20px 0;
+  border: none;
+  border-radius: 5px;
+  background: rgb(172, 21, 192);
+  color: white;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.block-answer-form__two-button {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.block-answer-form__btn--cancel {
+  background: rgb(167, 165, 165);
+  margin-right: 5px;
+}
+</style>

--- a/src/pages/PostDetails.vue
+++ b/src/pages/PostDetails.vue
@@ -60,18 +60,18 @@
             <!-- 投稿者 -->
             <div
               class="item-bottom__author"
-              @click="moveToUserPage(post.user.id)"
+              @click="moveToUserPage(postUserData('id'))"
             >
               <!-- アイコン -->
               <div class="block-icon">
                 <img
                   class="block-icon__img"
-                  :src="post.user.icon_url"
-                  v-if="post.user.icon_url"
+                  :src="postUserData('icon_url')"
+                  v-if="postUserData('icon_url')"
                 />
               </div>
               <!-- ユーザー名 -->
-              <p class="item-bottom__username">{{ post.user.username }}</p>
+              <p class="item-bottom__username">{{ postUserData('username') }}</p>
             </div>
           </div>
           <!-- カテゴリー -->
@@ -147,24 +147,12 @@
           <!-- ログイン済みかつ自分の質問でない場合 -->
           <template v-if="isLoggedIn && !isYourPost">
             <!-- まだ回答していない場合 -->
-            <template v-if="!haveYouAnswered">
-              <textarea
-                class="form-answer__textarea"
-                placeholder="回答を投稿する"
-                v-model="newAnswer"
-              ></textarea>
-              <ValidationMessage
-                class="form-answer__validation"
-                :messages="answerValidations"
-              />
-              <button 
-                class="form-answer__btn" 
-                @click="postAnswer" 
-                :disabled="isDisabled.postAnswer"
-              >
-                回答
-              </button>
-            </template>
+            <AnswerForm 
+              :buttonFunc="postAnswer"
+              :isDisabled="isDisabled.postAnswer"
+              :validations="answerValidations"
+              v-if="!haveYouAnswered" 
+            />
             <!-- 既に回答している場合 -->
             <p class="form-answer__text form-answer__text--answered" v-else>
               この質問には回答済みです
@@ -232,7 +220,21 @@
 
       <!-- 回答 -->
       <div class="block-content">
-        <p class="block-content__title">{{ post.answers.length }}件の回答</p>
+        <div class="block-rate" v-show="answerLength">
+          <p class="block-rate__title">質問内容に対する物件の評価の比率</p>
+          <div class="item-rate">
+            <span 
+              class="item-rate__span item-rate__span--good"
+              :style="evaluationWidth(1)"
+            ></span>
+            <span 
+              class="item-rate__span item-rate__span--bad"
+              :style="evaluationWidth(2)"
+            ></span>
+          </div>
+          <p class="block-rate__help">※ 評価：普通は比率に含まれません</p>
+        </div>
+        <p class="block-content__title">{{ answerLength }}件の回答</p>
         <section
           class="block-content__section"
           v-for="answer in post.answers"
@@ -245,6 +247,39 @@
               !getEditAnswerData(answer.id).isDeleting
             "
           >
+            <div class="block-evaluation">
+              <p class="block-evaluation__title">質問に対する物件の評価</p>
+              <div 
+                class="block-evaluation__item block-evaluation__item--normal" 
+                v-show="answer.evaluation === 0"
+              >
+                <fa-icon 
+                  class="block-evaluation__icon" 
+                  icon="meh-blank" 
+                />
+                <span class="block-evaluation__text">普通</span>
+              </div>
+              <div 
+                class="block-evaluation__item block-evaluation__item--good" 
+                v-show="answer.evaluation === 1"
+              >
+                <fa-icon 
+                  class="block-evaluation__icon" 
+                  icon="laugh" 
+                />
+                <span class="block-evaluation__text">良い</span>
+              </div>
+              <div 
+                class="block-evaluation__item block-evaluation__item--bad" 
+                v-show="answer.evaluation === 2"
+              >
+                <fa-icon 
+                  class="block-evaluation__icon" 
+                  icon="frown" 
+                />
+                <span class="block-evaluation__text">悪い</span>
+              </div>
+            </div>
             <p class="block-content__text">{{ answer.content }}</p>
             <div class="item-bottom">
               <a
@@ -252,23 +287,23 @@
                 href=""
                 v-show="!answer.likedBy.find((el) => el.id === userId)"
                 @click.prevent="like(answer.id)"
-                >いいね {{ answer.likedBy.length }}</a
+                >いいね {{ likeLength(answer) }}</a
               >
               <a
                 class="item-bottom__btn item-bottom__btn--active"
                 href=""
                 v-show="answer.likedBy.find((el) => el.id === userId)"
                 @click.prevent="dislike(answer.id)"
-                >いいね {{ answer.likedBy.length }}</a
+                >いいね {{ likeLength(answer) }}</a
               >
               <div
                 class="item-bottom__author"
-                @click="moveToUserPage(answer.user.id)"
+                @click="moveToUserPage(answerUserData(answer, 'id'))"
               >
                 <div class="block-icon">
-                  <img class="block-icon__img" :src="answer.user.icon_url" />
+                  <img class="block-icon__img" :src="answerUserData(answer, 'icon_url')" />
                 </div>
-                <p class="item-bottom__username">{{ answer.user.username }}</p>
+                <p class="item-bottom__username">{{ answerUserData(answer, 'username') }}</p>
               </div>
             </div>
             <p
@@ -284,7 +319,7 @@
                 (編集済み)</span
               >
             </p>
-            <div class="item-icon" v-if="userId === answer.user.id">
+            <div class="item-icon" v-if="userId === answerUserData(answer, 'id')">
               <fa-icon
                 class="item-icon__icon"
                 icon="edit"
@@ -303,37 +338,20 @@
           <!-- 回答編集時 -->
           <div
             class="form-answer"
-            v-show="
-              userId === answer.user.id &&
+            v-if="
+              userId === answerUserData(answer, 'id') &&
               getEditAnswerData(answer.id).isEditing
             "
           >
-            <textarea
-              class="form-answer__textarea"
-              placeholder="回答を入力"
-              v-model="getEditAnswerData(answer.id).content"
-            ></textarea>
-            <ValidationMessage
-              class="form-answer__validation"
-              :messages="getEditAnswerData(answer.id).validations"
+            <AnswerForm 
+              :buttonFunc="editAnswer"
+              :isDisabled="isDisabled.editAnswer"
+              :validations="getEditAnswerData(answer.id).validations"
+              :isTwoButton="true" 
+              :cancelFunc="switchEditAnswerData"
+              :answerId="answer.id"
+              :defaultData="getEditAnswerData(answer.id)"
             />
-            <div class="form-answer__block-btn">
-              <button
-                class="form-answer__btn form-answer__btn--cancel"
-                @click="
-                  switchEditAnswerData(answer.id, false, { cancel: true })
-                "
-              >
-                キャンセル
-              </button>
-              <button 
-                class="form-answer__btn" 
-                @click="editAnswer(answer.id)"
-                :disabled="isDisabled.editAnswer" 
-              >
-                保存
-              </button>
-            </div>
           </div>
 
           <!-- 回答削除時 -->
@@ -368,7 +386,10 @@
             <!-- コメントフォーム -->
             <div
               class="form-comment"
-              v-if="userId === answer.user.id || userId === post.user.id"
+              v-if="
+                userId === answerUserData(answer, 'id') || 
+                userId === postUserData('id')
+              "
             >
               <textarea
                 class="form-comment__textarea"
@@ -509,7 +530,7 @@
             </ul>
           </div>
         </section>
-        <p class="block-content__no-text" v-if="!post.answers.length">
+        <p class="block-content__no-text" v-if="!answerLength">
           まだ回答がありません
         </p>
       </div>
@@ -527,6 +548,7 @@ import ValidationMessage from "@/components/ValidationMessage";
 import SidePostList from "@/components/SidePostList";
 import AddressForm from "@/components/AddressForm";
 import CategoryForm from "@/components/CategoryForm";
+import AnswerForm from "@/components/AnswerForm";
 import Tag from "@/components/Tag";
 import moment from "moment";
 import addressValidationMixin from "@/mixins/addressValidationMixin";
@@ -542,39 +564,12 @@ export default {
     AddressForm,
     CategoryForm,
     Tag,
+    AnswerForm,
   },
   mixins: [addressValidationMixin, addressData],
   data() {
     return {
-      // 参照エラーが発生するので空のデータを追加
-      post: {
-        // 表示する投稿
-        id: "",
-        title: "",
-        text: "",
-        updatedAt: "",
-        createdAt: "",
-        user: {
-          id: "",
-          icon_url: "",
-          username: "",
-        },
-        answers: [
-          // 投稿についた回答
-          {
-            id: "",
-            content: "",
-            user: {
-              id: "",
-              username: "",
-              icon_url: "",
-            },
-            updatedAt: "",
-            likedBy: [], // 回答にいいねしたユーザーのIDのリスト
-          },
-        ],
-      },
-      newAnswer: "", // 新しい回答文
+      post: {},
       newComments: {}, // 新しいコメント
       editAnswerData: {}, // 回答の編集用データ
       editCommentData: {}, // コメントの編集用データ
@@ -641,11 +636,11 @@ export default {
     },
     // 質問に回答済みかどうか
     haveYouAnswered() {
-      return this.post.answers.some((el) => el.user.id === this.userId);
+      return this.post.answers?.some((el) => el.user.id === this.userId);
     },
     // 自分の質問かどうか
     isYourPost() {
-      return this.post.user.id === this.userId;
+      return this.postUserData('id') === this.userId;
     },
     // 所在地の初期値を設定
     addressDataProps() {
@@ -656,9 +651,27 @@ export default {
         buildingName: this.post.address?.["buildingName"],
       };
     },
-    // カテゴリーの数を返す
+    // カテゴリー数
     categoryLength() {
       return this.post.categories?.length;
+    },
+    // 回答数
+    answerLength() {
+      return this.post.answers?.length;
+    },
+    evaluationWidth() {
+      return (type) => {
+        const targetCount = this.post.answers?.filter(
+          (el) => el.evaluation === type
+        ).length;
+        const evaluationCount = this.post.answers?.filter(
+          (el) => el.evaluation !== 0
+        ).length;
+        const rate = evaluationCount ? Math.round(
+          targetCount / evaluationCount * 100
+        ) : 0;
+        return `width: ${rate}%;`;
+      }
     },
   },
   methods: {
@@ -718,6 +731,10 @@ export default {
     // コメントの数
     commentLength(answer) {
       return answer.comments?.length;
+    },
+    // いいねの数
+    likeLength(answer) {
+      return answer.likedBy?.length;
     },
     // コメント表示数
     commentLimitCount(comments) {
@@ -838,7 +855,7 @@ export default {
       this.isDisabled.updatePost = false;
     },
     // 回答を投稿する
-    async postAnswer() {
+    async postAnswer(answerData) {
       this.isDisabled.postAnswer = true;
       if (!this.isLoggedIn) {
         this.$router.push("/login");
@@ -849,14 +866,14 @@ export default {
       this.answerValidations = [];
 
       // 回答のバリデーション
-      if (!this.newAnswer) {
+      if (!answerData.content) {
         this.answerValidations.push("回答を入力してください");
         this.isDisabled.postAnswer = false;
         return;
       }
 
       const params = {
-        content: this.newAnswer,
+        ...answerData,
         questionId: this.postId,
         respondentId: this.userId,
       };
@@ -871,8 +888,6 @@ export default {
       // 回答の編集用データを更新
       this.setEditAnswerData(this.post.answers);
 
-      // フォームの文章を初期化
-      this.newAnswer = "";
       this.isDisabled.postAnswer = false;
     },
     // 投稿を削除
@@ -918,11 +933,11 @@ export default {
       this.post = data;
     },
     // 回答を編集
-    async editAnswer(answerId) {
+    async editAnswer(params, answerId) {
       this.isDisabled.editAnswer = true;
-      this.editAnswerData[answerId].validations = [];
 
-      if (!this.editAnswerData[answerId].content) {
+      this.editAnswerData[answerId].validations = [];
+      if (!params.content) {
         this.editAnswerData[answerId].validations.push(
           "回答を入力してください"
         );
@@ -930,14 +945,12 @@ export default {
         return;
       }
 
-      const params = {
-        content: this.editAnswerData[answerId].content,
-      };
       await apiClient.patch("/answers/update/" + answerId + "/", params);
 
       // 回答を更新
       const { data } = await apiClient.get("/posts/post/" + this.postId + "/");
       this.post = data;
+      this.setEditAnswerData(this.post.answers);
 
       // 回答編集フォームを閉じる
       this.editAnswerData[answerId].isEditing = false;
@@ -1043,6 +1056,7 @@ export default {
           isEditing: false,
           isDeleting: false,
           content: el.content,
+          evaluation: el.evaluation,
           validations: [],
         };
       });
@@ -1050,6 +1064,12 @@ export default {
     // 回答の編集用データを取得
     getEditAnswerData(answerId) {
       return this.editAnswerData[answerId] || {};
+    },
+    postUserData(column) {
+      return this.post.user?.[column];
+    },
+    answerUserData(answerData, column) {
+      return answerData.user?.[column];
     },
   },
   watch: {
@@ -1298,15 +1318,6 @@ ul {
   padding-top: 10px;
 }
 
-.form-answer__textarea {
-  height: 130px;
-  padding: 10px;
-  border-color: silver;
-  border-radius: 3px;
-  font-size: 1.1em;
-  letter-spacing: 2px;
-}
-
 .form-answer__text {
   margin: 0;
   font-size: 0.8em;
@@ -1378,6 +1389,19 @@ ul {
   margin: 0;
 }
 
+.block-radio {
+  font-size: 0.8em;
+}
+
+.block-radio__help {
+  font-size: 1.1em;
+  margin: 10px 0 5px;
+}
+
+.block-radio__item + .block-radio__item {
+  margin-left: 10px;
+}
+
 /* 回答日時 */
 .block-content__updated-at--answer {
   display: flex;
@@ -1388,6 +1412,76 @@ ul {
 /* 回答 */
 .block-content__section + .block-content__section {
   border-top: 1px solid silver;
+}
+
+.block-evaluation__title {
+  margin-bottom: 8px;
+  color: gray;
+  font-size: 0.8em;
+}
+
+.block-evaluation__icon {
+  font-size: 1.8em;
+}
+
+.block-evaluation__item {
+  display: flex;
+  align-items: center;
+}
+
+.block-evaluation__item--good {
+  color: rgb(255, 70, 70);
+}
+
+.block-evaluation__item--normal {
+  color: rgb(128, 127, 127);
+}
+
+.block-evaluation__item--bad {
+  color: rgb(29, 55, 202);
+}
+
+.block-evaluation__text {
+  margin-left: 10px;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.block-rate {
+  padding: 10px 0 15px;
+}
+
+.block-rate__title {
+  margin: 0 0 10px;
+  color: gray;
+  font-size: 0.9em;
+}
+
+.block-rate__help {
+  margin: 5px 0 0;
+  color: rgb(85, 83, 83);
+  font-size: 0.7em;
+}
+
+.item-rate {
+  height: 20px;
+  overflow: hidden;
+  border-radius: 1.5em;
+  background: silver;
+}
+
+.item-rate__span {
+  display: inline-block;
+  vertical-align: top;
+  height: 100%;
+}
+
+.item-rate__span--good {
+  background: rgb(255, 70, 70);
+}
+
+.item-rate__span--bad {
+  background: rgb(29, 55, 202);
 }
 
 /* 回答がない場合 */


### PR DESCRIPTION
## Issue
#120 

## 概要
回答投稿時に物件の評価も一緒に投稿できるよう仕様を変更

以下詳細
- 回答フォーム用コンポ―ネントであるAnswerForm.vueを作成し、回答投稿フォームと回答編集フォームの部分を共通化
- 回答投稿・編集時に物件の評価をつけられるようにAnswerForm.vueにラジオボタンを追加
- 質問詳細画面に物件の評価の比率を描画する機能を追加

## 動作確認内容
質問詳細画面で以下が正常に機能することを確認
1. 回答が投稿できること
2. 回答が編集できること
3. 回答の評価の比率が描画されること

#### 回答投稿フォーム
![image](https://user-images.githubusercontent.com/83702606/141448531-3606e599-f175-44ba-97fe-0f313bab26d4.png)

#### 回答編集フォーム
![image](https://user-images.githubusercontent.com/83702606/141448867-0a86cfd8-b40d-4bc1-8624-36a9a9f0a226.png)

#### 良い評価
![image](https://user-images.githubusercontent.com/83702606/141448778-032c656e-1921-49ec-98be-2bcd955161a1.png)

#### 普通の評価
![image](https://user-images.githubusercontent.com/83702606/141448976-3a2bc192-8abd-4dbd-b90d-8be5cf23e48f.png)

#### 悪い評価
![image](https://user-images.githubusercontent.com/83702606/141449056-2d3259b1-e92a-4aa3-a0c4-a3d7d52c6745.png)

#### 回答の比率
![image](https://user-images.githubusercontent.com/83702606/141449226-bf06a73b-ea8a-40ec-b1ab-9e9fe5a1abf2.png)

## 関連リンク
https://github.com/tko-asn/bukken-api/pull/99