### PR TITLE
【ローディング機能】ローディング機能をコンポーネントで管理するよう仕様を変更

### DIFF
--- a/src/components/AnswerList.vue
+++ b/src/components/AnswerList.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="block-answer-list">
     <transition name="fade" mode="out-in" appear>
-      <div class="block-answer-list__spin" v-if="isLoading">
-        <vue-loaders name="ball-spin-fade-loader" color="black" scale="1" />
-      </div>
+      <Loader v-if="isLoading" />
       <transition-group
         name="fadeGroup"
         class="block-answer-list__list-answer"
@@ -69,10 +67,13 @@
 <script>
 import apiClient from "@/axios";
 import Pagination from "./Pagination.vue";
-import { mapGetters } from "vuex";
+import Loader from "./Loader.vue";
 
 export default {
-  components: { Pagination },
+  components: { 
+    Pagination,
+    Loader,
+  },
   props: {
     answerType: String,
     userIdProps: String,
@@ -89,16 +90,16 @@ export default {
         answer: 1,
         like: 1,
       },
+      isLoading: true,
     };
   },
   async created() {
     this.getAnswers(1);
-  },
-  computed: {
-    ...mapGetters("home", ["isLoading"]),
+    this.isLoading = false;
   },
   methods: {
     async getAnswers(page) {
+      this.isLoading = true;
       let route;
       if (this.answerType === "answer") {
         route = `/answers/user/${this.userIdProps}/${page}/`;
@@ -109,6 +110,7 @@ export default {
       this.answers = data.answers;
       this.total = data.total;
       this.page[this.answerType] = page;
+      this.isLoading = false;
     },
     detailPage(postId) {
       this.$router.push({ name: "postDetails", params: { postId } });
@@ -131,7 +133,7 @@ export default {
   list-style: none;
   display: flex;
   justify-content: center;
-  padding: 20px 0 0;
+  padding: 30px 0 0;
   flex-wrap: wrap;
 }
 

--- a/src/components/Loader.vue
+++ b/src/components/Loader.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="block-loader">
+    <vue-loaders name="ball-spin-fade-loader" color="gray" scale="1" />
+  </div>
+</template>
+
+<style scoped>
+.block-loader {
+  text-align: center;
+}
+</style>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -11,7 +11,7 @@
             'item-page__link--disabled': pageNumber === 1,
             'item-page__link--end': pageNumber === 1,
           }"
-          @click.prevent="movePage(pageNumber - 1)"
+          @click.prevent="paginationFunc(pageNumber - 1)"
         >
           前へ
         </a>
@@ -25,7 +25,7 @@
             'item-page__link--current': num === pageNumber,
             'item-page__link--disabled': num === pageNumber,
           }"
-          @click.prevent="movePage(num)"
+          @click.prevent="paginationFunc(num)"
           v-show="displayPageButton(num)"
         >
           {{ num }}
@@ -41,7 +41,7 @@
             'item-page__link--disabled': total === pageNumber,
             'item-page__link--end': total === pageNumber,
           }"
-          @click.prevent="movePage(pageNumber + 1)"
+          @click.prevent="paginationFunc(pageNumber + 1)"
         >
           次へ
         </a>
@@ -57,7 +57,7 @@
             'item-page__link--current': num === pageNumber,
             'item-page__link--disabled': num === pageNumber,
           }"
-          @click.prevent="movePage(num)"
+          @click.prevent="paginationFunc(num)"
           v-show="displayPageButton(num)"
           v-for="num in total"
           :key="num"
@@ -75,7 +75,7 @@
             'item-page__link--disabled': pageNumber === 1,
             'item-page__link--end': pageNumber === 1,
           }"
-          @click.prevent="movePage(pageNumber - 1)"
+          @click.prevent="paginationFunc(pageNumber - 1)"
         >
           前へ
         </a>
@@ -88,7 +88,7 @@
             'item-page__link--disabled': total === pageNumber,
             'item-page__link--end': total === pageNumber,
           }"
-          @click.prevent="movePage(pageNumber + 1)"
+          @click.prevent="paginationFunc(pageNumber + 1)"
         >
           次へ
         </a>
@@ -130,12 +130,6 @@ export default {
       } else if (num > this.pageNumber) {
         return num <= this.pageNumber + 2;
       }
-    },
-    // ページ移動
-    async movePage(page) {
-      this.$store.commit("home/setIsLoading", true);
-      await this.paginationFunc(page);
-      this.$store.commit("home/setIsLoading", false);
     },
   },
 };

--- a/src/components/PostFilter.vue
+++ b/src/components/PostFilter.vue
@@ -146,8 +146,6 @@ export default {
     },
     // 絞り込み
     async filter() {
-      this.$store.commit("home/setIsLoading", true);
-
       this.switchType("filter");
       const params = {
         categories: this.selectedCategories,
@@ -158,8 +156,6 @@ export default {
         paramsSerializer: (params) => qs.stringify(params),
       };
       await this.filterPosts(1, filter);
-
-      this.$store.commit("home/setIsLoading", false);
     },
     // フィルターの開閉
     toggleFilter() {

--- a/src/components/PostList.vue
+++ b/src/components/PostList.vue
@@ -3,9 +3,7 @@
   <div class="container-post-list">
     <!-- 投稿がある場合 -->
     <transition name="fade" mode="out-in" appear>
-      <div class="container-post-list__loader" v-if="isLoading">
-        <vue-loaders name="ball-spin-fade-loader" color="black" scale="1" />
-      </div>
+      <Loader v-if="isLoading" />
       <transition-group
         name="fadeGroup"
         class="container-post-list__block-posts"
@@ -61,15 +59,21 @@
 </template>
 
 <script>
+import Loader from "@/components/Loader";
 import addressData from "@/mixins/addressData";
-import { mapGetters } from "vuex";
 
 export default {
   props: {
     postList: Array, // 投稿リスト
+    isLoading: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  components: {
+    Loader,
   },
   computed: {
-    ...mapGetters("home", ["isLoading"]),
     // 投稿リストの要素数が奇数か判定
     isOdd() {
       return this.postList.length % 2 !== 0;

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -33,8 +33,6 @@ export default {
   },
   methods: {
     async search() {
-      this.$store.commit("home/setIsLoading", true);
-
       this.switchType("search");
       const params = {
         keyword: this.keyword,
@@ -44,8 +42,6 @@ export default {
         paramsSerializer: (params) => qs.stringify(params),
       };
       await this.searchPosts(1, search);
-
-      this.$store.commit("home/setIsLoading", false);
     },
   },
   watch: {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -184,7 +184,10 @@
           :switchType="switchPostType"
           v-show="$route.name === 'home'"
         />
-        <router-view :postList="postObj[postType].posts" />
+        <router-view 
+          :postList="postObj[postType].posts" 
+          :isLoading="isLoading" 
+        />
         <!-- ページネーション -->
         <transition name="fade">
           <Pagination
@@ -264,6 +267,7 @@ export default {
         filter: this.getFilteredPosts,
         search: this.getSearchedPosts,
       },
+      isLoading: true,
     };
   },
   async created() {
@@ -272,15 +276,15 @@ export default {
       this.getFollowees(1),
       this.getFollowers(1),
     ]);
-    this.setIsLoading(false);
+    this.isLoading = false;
   },
   computed: {
     ...mapGetters("auth", ["userId", "isLoggedIn"]),
-    ...mapGetters("home", ["showSideMenu", "isLoading"]),
+    ...mapGetters("home", ["showSideMenu"]),
     ...mapGetters("followeeId", ["followeeId"]),
   },
   methods: {
-    ...mapMutations("home", ["toggleSideMenu", "hideSideMenu", "setIsLoading"]),
+    ...mapMutations("home", ["toggleSideMenu", "hideSideMenu"]),
     async getLatestPosts(page) {
       const { data } = await apiClient.get(`/posts/page/${page}/`);
       this.postObj.home.posts = data.posts;
@@ -336,11 +340,14 @@ export default {
       if (this.$route.name !== "home") {
         this.$router.push("/");
       }
+      this.isLoading = true;
       await this.getPostMethods[type](this.postObj[type].page);
       this.activeMenu = this.postType = type;
+      this.isLoading = false;
     },
     // ページネーション・フィルタリング・検索
     async getPosts(page, payload = {}) {
+      this.isLoading = true;
       if ("params" in payload) {
         // myPostsで絞り込み
         if (this.activeMenu === "myPosts") {
@@ -365,6 +372,7 @@ export default {
       } else {
         await this.getPostMethods[this.postType](page);
       }
+      this.isLoading = false;
     },
     switchPostType(type) {
       this.postType = type;
@@ -421,11 +429,6 @@ export default {
     if (to.name === "home") {
       this.getLatestPosts(1);
     }
-    next();
-  },
-  beforeRouteLeave(to, from, next) {
-    // isLoadingを初期化
-    this.$store.commit("home/setIsLoading", true);
     next();
   },
 };

--- a/src/pages/UserAnswerView.vue
+++ b/src/pages/UserAnswerView.vue
@@ -68,7 +68,6 @@ export default {
   async created() {
     const { data } = await apiClient.get(`/users/${this.userId}/`);
     this.userData = data;
-    this.$store.commit("home/setIsLoading", false);
   },
   computed: {
     ...mapGetters("home", ["showSideMenu"]),
@@ -77,10 +76,6 @@ export default {
     switchAnswerType(type) {
       this.type = type;
     },
-  },
-  beforeRouteLeave(to, from, next) {
-    this.$store.commit("home/setIsLoading", true);
-    next();
   },
 };
 </script>

--- a/src/pages/UserPosts.vue
+++ b/src/pages/UserPosts.vue
@@ -24,7 +24,7 @@
       :switchType="switchPostType"
     />
 
-    <PostList :postList="postList" />
+    <PostList :postList="postList" :isLoading="isLoading" />
     <transition name="fadePagination">
       <Pagination
         :total="total"
@@ -64,6 +64,7 @@ export default {
       page: 0,
       postType: "",
       conditions: {},
+      isLoading: true,
     };
   },
   created() {
@@ -72,12 +73,13 @@ export default {
       apiClient.get(`/users/${this.userId}/`), // ユーザーデータを取得
     ]).then((values) => {
       this.userData = values[1].data;
-      this.$store.commit("home/setIsLoading", false);
+      this.isLoading = false;
     });
   },
   methods: {
     async getPosts(page, payload = {}) {
-      let route = "/posts/" + this.userId + "/page/" + page + "/";
+      this.isLoading = true;
+      let route = `/posts/${this.userId}/page/${page}/`;
       if (this.postType === "filter") {
         route = `/posts/filter/query/page/${page}/`;
       } else if (this.postType === "search") {
@@ -93,15 +95,11 @@ export default {
       this.postList = data.posts;
       this.total = data.total;
       this.page = page;
+      this.isLoading = false;
     },
     switchPostType(type) {
       this.postType = type;
     },
-  },
-  beforeRouteLeave(to, from, next) {
-    // isLoadingを初期化
-    this.$store.commit("home/setIsLoading", true);
-    next();
   },
 };
 </script>

--- a/src/pages/UserView.vue
+++ b/src/pages/UserView.vue
@@ -302,7 +302,6 @@ export default {
       this.displayedSelfIntroduction = this.selfIntroduction;
       this.displayedIconURL = this.iconURL;
     }
-    this.$store.commit("home/setIsLoading", false);
   },
   methods: {
     ...mapActions("followeeId", ["createFolloweeId", "deleteFolloweeId"]),
@@ -408,10 +407,6 @@ export default {
   },
   beforeRouteUpdate(to, from, next) {
     this.showSideMenu = false;
-    next();
-  },
-  beforeRouteLeave(to, from, next) {
-    this.$store.commit("home/setIsLoading", true);
     next();
   },
 };

--- a/src/store/modules/home.js
+++ b/src/store/modules/home.js
@@ -1,11 +1,9 @@
 const state = {
   showSideMenu: false, // SP・タブレット状態でのメニューの表示切り替え
-  isLoading: true,
 };
 
 const getters = {
   showSideMenu: state => state.showSideMenu,
-  isLoading: state => state.isLoading,
 };
 
 const mutations = {
@@ -16,9 +14,6 @@ const mutations = {
   // SP・タブレット状態のでのサイドメニューの非表示
   hideSideMenu(state) {
     state.showSideMenu = false;
-  },
-  setIsLoading(state, boolean) {
-    state.isLoading = boolean;
   },
 };
 


### PR DESCRIPTION
## Issue
#126 

## 概要
Vuexで管理していたローディング機能をコンポーネントで管理するように仕様を変更

以下詳細　
- Vuexからローディング機能を削除
- ローディング用コンポーネントであるLoader.vueを作成
- トップ画面、ユーザーの投稿画面、回答表示画面にルーターの表示・非表示を制御する機能を追加
- コンポーネントからVuexのローディング機能の処理を削除

## 動作確認内容
以下のページを開いて正常にローダーが表示されることを確認

#### トップ画面
![image](https://user-images.githubusercontent.com/83702606/142415824-6b5156ab-bae9-4dc4-9897-b287fa71a5e2.png)

#### ユーザーの投稿画面
![image](https://user-images.githubusercontent.com/83702606/142415948-38d7c077-eb41-4235-83a0-3b7a0daf5c08.png)

#### 回答表示画面
![image](https://user-images.githubusercontent.com/83702606/142416153-f4a8c270-fb57-40c5-bb4f-0b2e17fda26b.png)
