### PR TITLE
【質問詳細画面】物件情報の項目に地図を追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,5 +21,6 @@
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
+    <script async src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAi-ypFtcISScCAEn6p_4CfV7Lefzn2AAY"></script>
   </body>
 </html>

--- a/src/mixins/addressData.js
+++ b/src/mixins/addressData.js
@@ -8,13 +8,27 @@ export default {
     postalCodeB(post) {
       return post.address?.["postalCode"].slice(3);
     },
+    // 都道府県
+    prefecture(post) {
+      return post.address?.["prefecture"];
+    },
+    // 市区町村
+    municipality(post) {
+      return post.address?.["municipality"];
+    },
+    townName(post) {
+      return post.address?.["townName"];
+    },
+    buildingName(post) {
+      return post.address?.["buildingName"];
+    },
     // 住所のデータを連結して返す
     addressData(post) {
       return (
-        post.address?.["prefecture"] +
-        post.address?.["municipality"] +
-        post.address?.["townName"] +
-        post.address?.["buildingName"]
+        this.prefecture(post) +
+        this.municipality(post) +
+        this.townName(post) +
+        this.buildingName(post)
       );
     },
   },


### PR DESCRIPTION
## Issue
#131 

## 概要
物件情報を表示する項目の位置を移動し、地図を表示する機能を追加

以下詳細
- 物件の所在地のデータを管理するmixinであるAddressData.jsを修正し、所在地のデータの形式を変更
- GoogleMapAPIを読み込む処理をindex.htmlに記述
- 質問詳細画面の物件情報の項目を移動
- 質問詳細画面に地図を表示する機能を追加

## 動作確認内容
質問詳細画面を開いて物件の情報とその所在地の地図が正常に表示されることを確認

PC
![image](https://user-images.githubusercontent.com/83702606/143244395-e174b2e5-3e46-46cc-9171-e5a7f19d7163.png)

SP
![image](https://user-images.githubusercontent.com/83702606/143244473-45c7518a-0714-4697-a755-6f755a7f0b8c.png)
