### PR TITLE
【質問詳細画面】サイドメニューとして表示する投稿リストに「人気の質問」を追加

### DIFF
--- a/src/components/SidePostList.vue
+++ b/src/components/SidePostList.vue
@@ -3,17 +3,21 @@
     <nav class="block-side__nav">
       <ul class="block-side__list">
         <li class="item">
-          <h3 class="item__title">最新の質問</h3>
+          <h3 class="item__title">{{ title }}</h3>
         </li>
-        <li v-for="post in posts" :key="post.id" class="item">
+        <li
+          v-for="(post, index) in posts"
+          :key="post.id"
+          class="item"
+          v-show="isHalf ? index < 5 : true"
+        >
           <a
             href=""
             class="item__link"
             @click.prevent="moveToPostPage(post.id)"
           >
-            <p class="item__text">
-              {{ post.property }}
-            </p>
+            <p class="item__text">{{ post.title }}</p>
+            <p class="item__text item__text--small">{{ post.property }}</p>
           </a>
         </li>
       </ul>
@@ -22,17 +26,20 @@
 </template>
 
 <script>
-import apiClient from "@/axios";
-
 export default {
-  data() {
-    return {
-      posts: [],
-    };
-  },
-  async created() {
-    const { data } = await apiClient.get("/posts/page/1/");
-    this.posts = data.posts;
+  props: {
+    posts: {
+      type: Array,
+      default: () => [],
+    },
+    title: {
+      type: String,
+      default: "",
+    },
+    isHalf: {
+      type: Boolean,
+      default: false,
+    },
   },
   methods: {
     // 投稿のページへ移動
@@ -49,7 +56,6 @@ export default {
 <style scoped>
 /* サイドメニュー */
 .block-side {
-  width: 25%;
   animation: scaleUp 0.5s;
 }
 
@@ -74,17 +80,26 @@ export default {
 }
 
 .item__link {
-  display: flex;
-  align-items: center;
+  display: block;
   height: 40px;
-  border-bottom: 2px solid rgb(194, 193, 193);
+  padding: 3px 5px;
+  border-bottom: 1px solid rgb(194, 193, 193);
   color: rgb(105, 104, 104);
   text-decoration: none;
 }
 
+.item__link:hover {
+  background: rgb(209, 209, 209);
+}
+
 .item__text {
+  margin: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.item__text--small {
+  font-size: 0.8em;
 }
 </style>

--- a/src/pages/PostDetails.vue
+++ b/src/pages/PostDetails.vue
@@ -219,7 +219,7 @@
               :style="evaluationWidth(2)"
             ></span>
           </div>
-          <p class="block-rate__help">※ 評価：普通は比率に含まれません</p>
+          <p class="block-rate__help">※ 評価:普通は比率に含まれません</p>
         </div>
         <p class="block-content__title">{{ answerLength }}件の回答</p>
         <section
@@ -524,8 +524,25 @@
       </div>
     </div>
 
-    <!-- サイドメニュー -->
-    <SidePostList class="container__list-side-post" />
+    <!-- PC・タブレットのサイドメニュー -->
+    <div 
+      :class="[
+        width >= 600 ? 
+        'container__list-side-post--pc' : 
+        'container__list-side-post--sp'
+      ]"
+    >
+      <SidePostList  
+        :posts="latestPosts" 
+        title="最新の質問"
+        v-if="latestPosts.length"
+      />
+      <SidePostList 
+        :posts="favoritePostRanking" 
+        title="人気の投稿"
+        v-if="favoritePostRanking.length"
+      />
+    </div>
   </div>
 </template>
 
@@ -546,6 +563,7 @@ import TextArea from "@/components/TextArea";
 import moment from "moment";
 import addressValidationMixin from "@/mixins/addressValidationMixin";
 import addressData from "@/mixins/addressData";
+import widthMixin from "@/mixins/widthMixin";
 
 export default {
   props: {
@@ -564,7 +582,7 @@ export default {
     MiddleInput,
     TextArea,
   },
-  mixins: [addressValidationMixin, addressData],
+  mixins: [addressValidationMixin, addressData, widthMixin],
   data() {
     return {
       post: {},
@@ -597,35 +615,33 @@ export default {
         deleteComment: false,
       },
       showMap: true,
+      latestPosts: [],
+      favoritePostRanking: [],
     };
   },
-  created() {
+  async created() {
     // ユーザーのお気に入りの投稿のidリスト取得
     if (this.isLoggedIn) {
       this.getFavoritePostList();
     }
-    apiClient.get(`/posts/post/${this.postId}/`).then(({ data }) => {
-      this.post = data; // 対象の投稿データをセット
 
-      // コメントの初期値を作成
-      this.post.answers.forEach((el) => {
-        this.newComments[el.id] = "";
-      });
+    const values = await Promise.all([
+      apiClient.get(`/posts/post/${this.postId}/`),
+      apiClient.get("/posts/page/1/"),
+      apiClient.get("/posts/favorite/post/ranking/1"),
+    ]);
 
-      // コメントの編集用データの初期値を作成
-      this.setEditCommentData(this.post.answers);
-      // 回答の編集用データの初期値を作成
-      this.setEditAnswerData(this.post.answers);
+    this.latestPosts = values[1].data.posts; // 最新の投稿
+    this.favoritePostRanking = values[2].data.posts; // お気に入りの投稿ランキング
 
-      // 編集用データ
-      this.editPostData.title = data.title;
-      this.editPostData.text = data.text;
-      this.editPostData.property = data.property;
-      this.editAddressData = { ...data.address };
-      this.editCategoryData = [...data.categories];
-      this.editAddressData.postalCodeA = this.postalCodeA(this.post);
-      this.editAddressData.postalCodeB = this.postalCodeB(this.post);
+    // 投稿の詳細を取得
+    this.post = values[0].data;
+    // コメントの初期値を作成
+    this.post.answers.forEach((el) => {
+      this.newComments[el.id] = "";
     });
+    // 編集用データをセット
+    this.setEditingData(this.post);
   },
   mounted() {
     this.getPropertyMap();
@@ -1100,26 +1116,31 @@ export default {
         }
       }, 500);
     },
+    setEditingData(postData) {
+      // コメントの編集用データの初期値を作成
+      this.setEditCommentData(postData.answers);
+      // 回答の編集用データの初期値を作成
+      this.setEditAnswerData(postData.answers);
+
+      // 編集用データ
+      this.editPostData.title = postData.title;
+      this.editPostData.text = postData.text;
+      this.editPostData.property = postData.property;
+      this.editAddressData = { ...postData.address };
+      this.editCategoryData = [...postData.categories];
+      this.editAddressData.postalCodeA = this.postalCodeA(postData);
+      this.editAddressData.postalCodeB = this.postalCodeB(postData);
+    },
   },
   watch: {
-    postId(val) {
-      // サイドバーからページをpostIdを切り替えたとき
-      apiClient.get(`/posts/post/${val}/`).then(({ data }) => {
-        this.post = data; // 対象の投稿データをセット
-        this.setEditCommentData(this.post.answers);
-        this.setEditAnswerData(this.post.answers);
-
-        // 編集用データ
-        this.editPostData.title = data.title;
-        this.editPostData.text = data.text;
-        this.editPostData.property = data.property;
-        this.editAddressData = { ...data.address };
-        this.editCategoryData = [...data.categories];
-        this.editAddressData.postalCodeA = this.postalCodeA(this.post);
-        this.editAddressData.postalCodeB = this.postalCodeB(this.post);
-
-        this.isEditingPost = false;
-      });
+    async postId(val) {
+      const values = await Promise.all([
+        apiClient.get(`/posts/post/${val}/`), // サイドバーからpostIdを切り替えたとき
+        this.getPropertyMap(),
+      ]);
+      this.post = values[0].data;
+      this.setEditingData(this.post);
+      this.isEditingPost = false;
     },
     isEditingPost(val) {
       if (!val) {
@@ -1151,7 +1172,7 @@ ul {
 
 /* 投稿詳細部分 */
 .container__item-post-details {
-  max-width: 700px;
+  min-width: 400px;
   width: 50%;
   margin-right: 50px;
   padding-top: 25px;
@@ -1549,20 +1570,25 @@ ul {
   cursor: pointer;
 }
 
+.container__list-side-post--pc {
+  width: 25%;
+  min-width: 185px;
+  margin-left: 10px;
+}
+
+.container__list-side-post--sp {
+  width: 90%;
+  padding: 0 0 40px;
+}
+
 @media screen and (max-width: 1024px) {
   .container {
-    width: 80%;
-    flex-direction: column;
+    width: 100%;
+    justify-content: space-around;
   }
 
   .container__item-post-details {
-    max-width: none;
-    width: 100%;
     margin: 0;
-  }
-
-  .container__list-side-post {
-    display: none;
   }
 
   .item-property__map {
@@ -1572,7 +1598,8 @@ ul {
 
 @media screen and (max-width: 599px) {
   .container {
-    width: 100%;
+    align-items: center;
+    flex-direction: column;
   }
 
   .block-content__title {
@@ -1605,6 +1632,8 @@ ul {
   }
 
   .container__item-post-details {
+    width: 100%;
+    min-width: 0;
     padding-top: 0;
   }
 


### PR DESCRIPTION
## Issue
#140 

## 概要
サイドメニューの投稿リストにお気に入り登録された投稿のランキングリストである「人気の質問」を追加

以下詳細
- 投稿リスト用コンポーネントであるSidePostList.vueの再利用性向上のため設計を一部変更
- 質問詳細画面にお気に入りの投稿ランキングのデータを受け取る処理を追加
- 上記のデータをSidePostList.vueを使って質問詳細画面に描画

## 動作確認内容
質問詳細画面を開いて「人気の投稿」が表示されることを確認

PC
![image](https://user-images.githubusercontent.com/83702606/145558418-dcd779ee-58af-4ddc-a28b-b9f17667b769.png)

SP
![image](https://user-images.githubusercontent.com/83702606/145558472-20cce159-2e13-4c3d-900e-603cc415b9ab.png)

## 関連リンク
API側のプルリクエスト
https://github.com/tko-asn/bukken-api/issues/101