### PR TITLE
【開発環境】開発環境をDockerへと移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+Dockerfile
+.dockerignore


### PR DESCRIPTION
## Issue
#142 

## 概要
開発環境をDockerへ移行

以下詳細
- 開発環境をDockerへと移行したが、Dockerfileと.dockerignoreは開発環境でしか使用しないファイルのため.gitignoreに記述した